### PR TITLE
add camelCased aliases for dashed-method-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ serf.connect(options, function(err){
 });
 ```
 
-All operations are supported, but not rigorously tested yet.
+All operations listed in the [Serf RPC docs](https://www.serf.io/docs/agent/rpc.html)
+are supported, but not all are rigorously tested yet. Methods with dashes in their names
+can either be called using bracket notation (e.g. `serf['members-filtered']`) or using
+their camel-cased aliases (e.g.`serf.membersFiltered(...)`).
 
 For specific details about these operations, consult the
 [official Serf RPC docs](http://www.serfdom.io/docs/agent/rpc.html).

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -62,6 +62,15 @@ var rpc = {
         "auth"
     ],
 
+    aliases: {
+      "members-filtered": "membersFiltered",
+      "install-key": "installKey",
+      "use-key": "useKey",
+      "remove-key": "removeKey",
+      "list-keys": "listKeys",
+      "force-leave": "forceLeave"
+    },
+
     handshake: function(fn){
         rpc.send("handshake", {}, function(err, response){
             return fn(err);

--- a/lib/serf.js
+++ b/lib/serf.js
@@ -24,6 +24,11 @@ exports.initialize = function(){
         };
     });
 
+    // Alias dashed-method-name to dashedMethodName
+    for (var alias in rpc.aliases) {
+        serf[rpc.aliases[alias]] = serf[alias];
+    }
+
     serf.listen = function(type, listener){
         serf.stream({ Type: type }, function(err, res){
             if(err)


### PR DESCRIPTION
This simply aliases all of the methods with dashed names to their camelCased equivalents so that you don't have to do stuff like `serf["members-filtered"](...)`. It's backwards-compatible (the dashed names are still there).

A few more PRs incoming :)
