### PR TITLE
Fix 'stop' function and add optional onSubscribe callback to listen method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,43 @@ All operations are supported, but not rigorously tested yet.
 For specific details about these operations, consult the
 [official Serf RPC docs](http://www.serfdom.io/docs/agent/rpc.html).
 
-There are two more convenience functions, listen and log, easing the use of
+There are two more convenience functions, `listen` and `log`, easing the use of
 stream and monitor.
+
+#### serf.listen(eventName, onEvent[, onSubscribe])
+* `eventName` \<String\> name of event, e.g. "member-join". May be comma-separated list.
+* `onEvent` \<Function\> handler. Passed the event data object and a "stop" function to call
+to stop listening.
+* `onSubscribe` \<Function\> optional, with the signature `(err, stopFn)`. Called after
+subscribing to handle errors when subscribing, and to provide the stop function so that
+it may be accessed prior to the first event invocation. If omitted, `listen` will throw
+if an error arises when subscribing.
+
+The `stopFn` is the same in both callbacks. It may optionally be called with a callback.
+
+```js
+var memberJoinStopFn;
+serf.listen("member-join,member-update", (data, stopFn) => {
+    console.log("members joined or updated", data);
+}, (err, stopFn) => {
+    if (err) return console.log("Error subscribing to event", err);
+    memberJoinStopFn = stopFn;
+});
+
+// Stop listening after 5 seconds.
+setTimeout(() => {
+    // Test if function is defined in case it takes a long time to subscribe.
+    if (memberJoinStopFn) memberJoinStopFn();
+}, 5000);
+
+// -Or-
+
+try {
+    serf.listen("member-join", (data, stopFn) => { /* ... */ });
+} catch (e) {
+    console.log("Error subscribing to event", e);
+}
+```
 
 ###Examples
 Example using the default RPC address, triggering a custom user event:
@@ -56,14 +91,14 @@ serf.connect(function(err){
     serf.event({"Name": "deploy", "Payload": "4f33de567283e4a456539b8dc493ae8a853a93f6", "Coalesce": false}, function(err, response){
         if(err)
             throw err;
-        else
-            console.log("Triggered the event!");
+        
+        console.log("Triggered the event!");
     });
 });
 
 serf.listen("user", function(data, stop) {
 	console.log('listen event!!', data);
-	// serf.stop();
+	// stop(); // call this to stop listening
 	// serf.leave(function(data) { console.log('leaving', data); });
 });
 

--- a/lib/serf.js
+++ b/lib/serf.js
@@ -24,17 +24,23 @@ exports.initialize = function(){
         };
     });
 
-    serf.listen = function(type, listener){
+    serf.listen = function(type, onEvent, onSubscribe){
         serf.stream({ Type: type }, function(err, res){
-            if(err)
+            if(err) {
+                if (typeof onSubscribe === "function") return onSubscribe(err);
                 throw err;
-            else{
-                serf.events.on(res.Seq, function(data){
-                    listener(data, function(){
-                        serf.stop({ Stop: res.Seq });
-                    });
-                });
             }
+
+            function stopFn(cb) {
+                if (typeof cb !== "function") cb = function () {};
+                serf.stop({ Stop: res.Seq }, cb);
+            }
+
+            serf.events.on(res.Seq, function(data){
+                onEvent(data, stopFn);
+            });
+
+            if (typeof onSubscribe === "function") onSubscribe(null, stopFn);
         });
     };
 


### PR DESCRIPTION
**Edit:** Just realized that the "stop" function that was being passed to the original `serf.listen` callback was actually broken (internally it called `serf.stop` without a callback). Fixed in this PR as well. (end edit)

Another backwards-compatible addition: an optional second callback to the `listen` function that allows for error handling without try/catch and that provides the stopFunction without having to wait for an event.

New docs added to readme:
#### serf.listen(eventName, onEvent[, onSubscribe])
- `eventName` <String> name of event, e.g. "member-join". May be comma-separated list.
- `onEvent` <Function> handler. Passed the event data object and a "stop" function to call
  to stop listening.
- `onSubscribe` <Function> optional, with the signature `(err, stopFn)`. Called after
  subscribing to handle errors when subscribing, and to provide the stop function so that
  it may be accessed prior to the first event invocation. If omitted, `listen` will throw
  if an error arises when subscribing.

The `stopFn` is the same in both callbacks. It may optionally be called with a callback.

``` js
var memberJoinStopFn;
serf.listen("member-join,member-update", (data, stopFn) => {
  console.log("members joined or updated", data);
}, (err, stopFn) => {
  if (err) return console.log("Error subscribing to event", err);
  memberJoinStopFn = stopFn;
});

// Stop listening after 5 seconds.
setTimeout(() => {
  memberJoinStopFn();
}, 5000);

// -Or-

try {
  serf.listen("member-join", (data, stopFn) => { /* ... */ });
} catch (e) {
  console.log("Error subscribing to event", e);
}
```
