### PR TITLE
Add disconnect method and fix up Network class

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ serf.listen("member-join,member-update", (data, stopFn) => {
 // Stop listening after 5 seconds.
 setTimeout(() => {
     // Test if function is defined in case it takes a long time to subscribe.
-    if (memberJoinStopFn) memberJoinStopFn();
+    if (memberJoinStopFn) {
+        memberJoinStopFn(function () { serf.disconnect(); });
+    } else serf.disconnect();
 }, 5000);
 
 // -Or-
@@ -80,6 +82,11 @@ try {
     console.log("Error subscribing to event", e);
 }
 ```
+
+#### serf.disconnect()
+Disconnects from the serf agent. If this is not called, then node.js will not exit because
+the underlying socket will remain open. That is to say, you must call this to close the
+underlying socket so that node.js may gracefully exit.
 
 ###Examples
 Example using the default RPC address, triggering a custom user event:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ serf.connect(options, function(err){
 });
 ```
 
-All operations are supported, but not rigorously tested yet.
+All operations listed in the [Serf RPC docs](https://www.serf.io/docs/agent/rpc.html)
+are supported, but not all are rigorously tested yet. Methods with dashes in their names
+can either be called using bracket notation (e.g. `serf['members-filtered']`) or using
+their camel-cased aliases (e.g.`serf.membersFiltered(...)`).
 
 For specific details about these operations, consult the
 [official Serf RPC docs](http://www.serfdom.io/docs/agent/rpc.html).

--- a/README.md
+++ b/README.md
@@ -43,8 +43,43 @@ their camel-cased aliases (e.g.`serf.membersFiltered(...)`).
 For specific details about these operations, consult the
 [official Serf RPC docs](http://www.serfdom.io/docs/agent/rpc.html).
 
-There are two more convenience functions, listen and log, easing the use of
+There are two more convenience functions, `listen` and `log`, easing the use of
 stream and monitor.
+
+#### serf.listen(eventName, onEvent[, onSubscribe])
+* `eventName` \<String\> name of event, e.g. "member-join". May be comma-separated list.
+* `onEvent` \<Function\> handler. Passed the event data object and a "stop" function to call
+to stop listening.
+* `onSubscribe` \<Function\> optional, with the signature `(err, stopFn)`. Called after
+subscribing to handle errors when subscribing, and to provide the stop function so that
+it may be accessed prior to the first event invocation. If omitted, `listen` will throw
+if an error arises when subscribing.
+
+The `stopFn` is the same in both callbacks. It may optionally be called with a callback.
+
+```js
+var memberJoinStopFn;
+serf.listen("member-join,member-update", (data, stopFn) => {
+    console.log("members joined or updated", data);
+}, (err, stopFn) => {
+    if (err) return console.log("Error subscribing to event", err);
+    memberJoinStopFn = stopFn;
+});
+
+// Stop listening after 5 seconds.
+setTimeout(() => {
+    // Test if function is defined in case it takes a long time to subscribe.
+    if (memberJoinStopFn) memberJoinStopFn();
+}, 5000);
+
+// -Or-
+
+try {
+    serf.listen("member-join", (data, stopFn) => { /* ... */ });
+} catch (e) {
+    console.log("Error subscribing to event", e);
+}
+```
 
 ###Examples
 Example using the default RPC address, triggering a custom user event:
@@ -59,14 +94,14 @@ serf.connect(function(err){
     serf.event({"Name": "deploy", "Payload": "4f33de567283e4a456539b8dc493ae8a853a93f6", "Coalesce": false}, function(err, response){
         if(err)
             throw err;
-        else
-            console.log("Triggered the event!");
+        
+        console.log("Triggered the event!");
     });
 });
 
 serf.listen("user", function(data, stop) {
 	console.log('listen event!!', data);
-	// serf.stop();
+	// stop(); // call this to stop listening
 	// serf.leave(function(data) { console.log('leaving', data); });
 });
 

--- a/lib/network.js
+++ b/lib/network.js
@@ -1,39 +1,33 @@
-var net = require('net').Socket();
+var net = require('net');
 var events = require('events');
 var _ = require("lodash");
 var msgpack = require([__dirname, "msgpack"].join("/"));
 
 function Network(options, fn){
     this.options = options;
+    this.socket = new net.Socket();
+    this.emitter = new events.EventEmitter();
 }
 
 Network.prototype.connect = function(fn){
     var serve;
     var self = this;
-
-    net.connect(this.options.rpc_port, this.options.rpc_host, function(){
-        net.on("data", function(data){
-            var decoded = msgpack.decode(data);
-            _.each(decoded, function(values, seq){
-                self.emitter.emit(seq, _.last(values));
-            });
+    
+    this.socket.on("data", function(data){
+        var decoded = msgpack.decode(data);
+        _.each(decoded, function(values, seq){
+            self.emitter.emit(seq, _.last(values));
         });
-        fn();
     });
 
-    net.on("error", function(){
-        var address = [self.options.rpc_host,self.options.rpc_port].join(":");
-        fn(new Error(["Could not connect to Serf RPC at", address].join(" ")));
-    });
-}
-
-Network.prototype.emitter = new events.EventEmitter();
+    this.socket.connect(this.options.rpc_port, this.options.rpc_host, fn);
+};
 
 Network.prototype.send = function(data_list, fn){
     var self = this;
 
     _.each(data_list, function(data){
-        net.write(msgpack.encode(data));
+        self.socket.write(msgpack.encode(data));
 
         if(_.has(data, "Seq")){
             self.emitter.once(data.Seq, function(response){
@@ -45,9 +39,9 @@ Network.prototype.send = function(data_list, fn){
             });
         }
     });
-
-}
+};
 
 Network.prototype.conn_track = {};
 
 module.exports = Network;
+

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -62,6 +62,15 @@ var rpc = {
         "auth"
     ],
 
+    aliases: {
+      "members-filtered": "membersFiltered",
+      "install-key": "installKey",
+      "use-key": "useKey",
+      "remove-key": "removeKey",
+      "list-keys": "listKeys",
+      "force-leave": "forceLeave"
+    },
+
     handshake: function(fn){
         rpc.send("handshake", {}, function(err, response){
             return fn(err);

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -21,6 +21,10 @@ var rpc = {
         });
     },
 
+    disconnect: function(){
+        rpc.network.socket.end();
+    },
+
     send: function(command, body, fn){
         var header_schema = schemas.header;
         var command_schema = schemas[command];

--- a/lib/serf.js
+++ b/lib/serf.js
@@ -24,6 +24,11 @@ exports.initialize = function(){
         };
     });
 
+    // Alias dashed-method-name to dashedMethodName
+    for (var alias in rpc.aliases) {
+        serf[rpc.aliases[alias]] = serf[alias];
+    }
+
     serf.listen = function(type, listener){
         serf.stream({ Type: type }, function(err, res){
             if(err)

--- a/lib/serf.js
+++ b/lib/serf.js
@@ -18,6 +18,10 @@ exports.initialize = function(){
         serf.events = rpc.network.emitter;
     };
 
+    serf.disconnect = function(){
+        rpc.disconnect();
+    };
+
     _.each(rpc.commands, function(command){
         serf[command] = function(body, fn){
             rpc.send(command, body, fn);

--- a/lib/serf.js
+++ b/lib/serf.js
@@ -29,17 +29,23 @@ exports.initialize = function(){
         serf[rpc.aliases[alias]] = serf[alias];
     }
 
-    serf.listen = function(type, listener){
+    serf.listen = function(type, onEvent, onSubscribe){
         serf.stream({ Type: type }, function(err, res){
-            if(err)
+            if(err) {
+                if (typeof onSubscribe === "function") return onSubscribe(err);
                 throw err;
-            else{
-                serf.events.on(res.Seq, function(data){
-                    listener(data, function(){
-                        serf.stop({ Stop: res.Seq });
-                    });
-                });
             }
+
+            function stopFn(cb) {
+                if (typeof cb !== "function") cb = function () {};
+                serf.stop({ Stop: res.Seq }, cb);
+            }
+
+            serf.events.on(res.Seq, function(data){
+                onEvent(data, stopFn);
+            });
+
+            if (typeof onSubscribe === "function") onSubscribe(null, stopFn);
         });
     };
 


### PR DESCRIPTION
:warning: (This is based on my master branch, which has my two other PRs merged into it.)

Adds a `serf.disconnect` method that closes the underlying socket, allowing node to gracefully exit.

Also fixes up the network class a bit:
- Do not call the `Network.connect` callback more than once. This was being called both after connecting and on any socket errors (the `net.on("error"...)` handler wasn't actually handling connection errors).
- Properly isolate members -- make new Socket and EventEmitter instances for each instance of Network. Begins to address #5.

(Trying to submit small, isolated PRs, but to do the rest of #5 it will be rather invasive.)
